### PR TITLE
DPMS-11800 Remove size propertie of forecastChartComponent

### DIFF
--- a/core/src/main/java/com/oxeanbits/forecastchart/ui/component/ForecastChartComponent.kt
+++ b/core/src/main/java/com/oxeanbits/forecastchart/ui/component/ForecastChartComponent.kt
@@ -42,7 +42,6 @@ class ForecastChartComponent(context: Context) : LinearLayoutComponent(context) 
     private var detailsEnable: Boolean = false
 
     override fun view() {
-        size(MATCH, WRAP)
         orientation(VERTICAL)
 
         if(detailsEnable) {


### PR DESCRIPTION
Fix from my last PRs: Even setting propertie from outside of component, this `WRAP` properties was forcing height to get always be minimal.